### PR TITLE
Add new method to ValueObject

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changes
+- Add `new` method to ValueObject to easily update the object without unfreezing it
 - Include more information in the internal non-translated error messages. E.g. the max size of a LessThenEqual definition
 - Renamed GreaterThen, GreaterThenEqual, LessThen and LessThenEqual to fix typo (Then VS Than) Backwards compatibility is ensured
 

--- a/lib/definition/value_object.rb
+++ b/lib/definition/value_object.rb
@@ -19,6 +19,10 @@ module Definition
       super(result.value.freeze)
     end
 
+    def new(args)
+      self.class.new(merge(args))
+    end
+
     class << self
       def conform(value)
         unless @definition

--- a/spec/lib/definition/value_object_spec.rb
+++ b/spec/lib/definition/value_object_spec.rb
@@ -66,6 +66,14 @@ describe Definition::ValueObject do
       expect { vo[:first_name] = "Anna" }.to raise_error(frozen_error)
     end
 
+    it "can be recreated with new args" do
+      vo = TestKeysValueObject.new(first_name: "Jon", last_name: "Doe")
+
+      updated_vo = vo.new(last_name: "Wayne")
+      expect(updated_vo.first_name).to eq("Jon")
+      expect(updated_vo.last_name).to eq("Wayne")
+    end
+
     it "raises error when data does not conform to the value object definition" do
       expect do
         TestKeysValueObject.new(first_name: "Jon", last_name: 1)


### PR DESCRIPTION
To allow easy "updating" of the ValueObject, without unfreezing it. So the object itself is still immutable, but it is easy to create a new object out of the existing one, just passing in the changes.