### PR TITLE
Add Definition::Initializer mixin

### DIFF
--- a/benchmark/initializer.rb
+++ b/benchmark/initializer.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require "bundler/inline"
+
+gemfile do
+  source "https://rubygems.org"
+  gem "dry-initializer", "~> 3.1"
+  gem "dry-types", "~> 1.5"
+  gem "awesome_print"
+  gem "benchmark-ips"
+  gem "pry"
+  gem "ruby-prof"
+  gem "sorbet"
+  gem "sorbet-runtime"
+  gem "definition", path: File.expand_path("../.", __dir__)
+end
+
+class SorbetUseCase
+  extend T::Sig
+
+  sig { params(phone: String, admin: T::Boolean).void }
+  def initialize(phone:, admin: false)
+    self.phone = phone
+    self.admin = admin
+  end
+
+  private
+
+  attr_accessor :phone, :admin
+end
+
+class DryUseCase
+  extend Dry::Initializer
+
+  option :phone, Dry::Types["strict.string"]
+  option :admin, Dry::Types["strict.bool"], default: false, optional: true
+end
+
+class DefinitionUseCase
+  include Definition::Initializer
+
+  required :phone, Definition.Type(String)
+  optional :admin, Definition.Boolean, default: false
+end
+
+puts "Benchmark with valid input data:"
+valid_data = { phone: "+49 3424 234234" }
+
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("sorbet") do
+    SorbetUseCase.new(**valid_data)
+  end
+
+  x.report("definition") do
+    DefinitionUseCase.new(**valid_data)
+  end
+
+  x.report("dry-struct") do
+    DryUseCase.new(**valid_data)
+  end
+
+  x.compare!
+end
+
+puts "Benchmark with invalid input data:"
+invalid_data = { phone: "+49 3424 234234", admin: "yes" }
+Benchmark.ips do |x|
+  x.config(time: 5, warmup: 2)
+
+  x.report("sorbet") do
+    SorbetUseCase.new(**invalid_data)
+  end
+
+  x.report("definition") do
+    DefinitionUseCase.new(**invalid_data)
+  rescue Definition::Initializer::InvalidArgumentError
+    nil
+  end
+
+  x.report("dry-struct") do
+    DryUseCase.new(**invalid_data)
+  rescue Dry::Types::ConstraintError
+    nil
+  end
+
+  x.compare!
+end

--- a/lib/definition/initializer.rb
+++ b/lib/definition/initializer.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module Definition
+  module Initializer
+    class InvalidArgumentError < ArgumentError
+      attr_accessor :conform_result
+
+      def initialize(conform_result)
+        super("Arguments passed into the initializer are invalid: #{conform_result.error_message}")
+        self.conform_result = conform_result
+      end
+    end
+
+    module ClassMethods
+      def required(name, *args)
+        _keys_definition.required(name, *args)
+        _define_attr_accessor(name)
+      end
+
+      def optional(name, *args, **kwargs)
+        _keys_definition.optional(name, *args, **kwargs)
+        _define_attr_accessor(name)
+      end
+
+      def _keys_definition
+        @_keys_definition ||= Definition.Keys {}
+      end
+
+      def _define_attr_accessor(key)
+        define_method(key) do
+          @_attributes.fetch(key, nil)
+        end
+        define_method("#{key}=") do |value|
+          @_attributes[key] = value
+        end
+        protected key
+        protected "#{key}="
+      end
+    end
+
+    def self.included(klass)
+      klass.extend(ClassMethods)
+    end
+
+    def initialize(**kwargs)
+      result = self.class._keys_definition.conform(kwargs)
+      raise InvalidArgumentError.new(result) unless result.passed?
+
+      @_attributes = result.value
+    end
+  end
+end

--- a/spec/lib/definition/initializer_spec.rb
+++ b/spec/lib/definition/initializer_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+describe Definition::Initializer do
+  let(:test_class) do
+    Class.new do
+      include Definition::Initializer
+    end
+  end
+
+  it "is initializable" do
+    test_class.new
+  end
+
+  context "when required and optional keyword arguments are configured" do
+    before do
+      test_class.required(:arg1, Definition.Type(String))
+      test_class.optional(:arg2, Definition.Type(String))
+    end
+
+    it "is initializable and exposes those arguments as private getters" do
+      instance = test_class.new(arg1: "value1", arg2: "value2")
+
+      expect(instance.send(:arg1)).to eq("value1")
+      expect(instance.send(:arg2)).to eq("value2")
+      expect { instance.public_send(:arg1) }.to raise_error(NoMethodError)
+      expect { instance.public_send(:arg2) }.to raise_error(NoMethodError)
+    end
+
+    it "allows the attributes to get changed" do
+      instance = test_class.new(arg1: "value1")
+      expect(instance.send(:arg1)).to eq("value1")
+
+      instance.send(:arg1=, "value2")
+      expect(instance.send(:arg1)).to eq("value2")
+    end
+
+    it "is initializable without the optional argument" do
+      instance = test_class.new(arg1: "value1")
+
+      expect(instance.send(:arg1)).to eq("value1")
+      expect(instance.send(:arg2)).to be nil
+    end
+
+    it "raises an error if the required argument is missing" do
+      expect { test_class.new }.to raise_error(Definition::Initializer::InvalidArgumentError,
+                                               /hash is missing key :arg1/)
+    end
+
+    it "raises an error if the required argument is not conforming its definition" do
+      expect { test_class.new(arg1: 1) }.to raise_error(
+        Definition::Initializer::InvalidArgumentError,
+        /hash fails validation for key arg1: { Is of type Integer instead of String }/
+      )
+    end
+
+    it "raises an error if the optional argument is not conforming its definition" do
+      expect { test_class.new(arg1: "value1", arg2: 1) }.to raise_error(
+        Definition::Initializer::InvalidArgumentError,
+        /hash fails validation for key arg2: { Is of type Integer instead of String }/
+      )
+    end
+
+    it "raises an error if both arguments are not conforming its definition" do
+      expect { test_class.new(arg1: 1, arg2: 1) }.to raise_error(
+        Definition::Initializer::InvalidArgumentError,
+        /hash fails validation for key arg1: .*, hash fails validation for key arg2:/
+      )
+    end
+
+    it "raises an error if the an unexpected keyword is passed in" do
+      expect { test_class.new(arg1: "value1", arg3: "value3") }.to raise_error(
+        Definition::Initializer::InvalidArgumentError,
+        /hash has extra key: :arg3/
+      )
+    end
+  end
+
+  context "when there is an optional argument with default" do
+    before do
+      test_class.optional(:arg1, Definition.Type(String), default: "default_value")
+    end
+
+    it "is initializable and assigns the default value if arg1 is not passed in" do
+      instance = test_class.new
+
+      expect(instance.send(:arg1)).to eq("default_value")
+    end
+  end
+
+  context "when there is an argument that coerces input" do
+    before do
+      test_class.required(:arg1, Definition.CoercibleType(Integer))
+    end
+
+    it "is initializable with a string and the private accessor returns the coerced value" do
+      instance = test_class.new(arg1: "1")
+
+      expect(instance.send(:arg1)).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
This adds a small helper feature that lets you validate keywords arguments of a class initializer with definitions