### PR TITLE
Fix model inheritance

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [1.1.1] - 2024-05-21
+### Fixed
+- Fixed Definition::Model inheritance
+
 ## [1.1.0] - 2023-11-22
 ### Changes
 - Improved performance

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    definition (1.1.0)
+    definition (1.1.1)
       activesupport
       i18n
 

--- a/lib/definition/model.rb
+++ b/lib/definition/model.rb
@@ -37,7 +37,12 @@ module Definition
       end
 
       def _definition
-        @_definition ||= ::Definition.Keys {}
+        @_definition ||= if superclass == ::Definition::Model
+                           ::Definition.Keys {}
+                         else
+                           # Create a deep copy of parent's definition
+                           Marshal.load(Marshal.dump(superclass._definition))
+                         end
       end
     end
 

--- a/lib/definition/version.rb
+++ b/lib/definition/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Definition
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end


### PR DESCRIPTION
At the moment, it's not possible to build a `Definition::Model` hierarchy.
Definitions of the superclass are not available in respective child class.

This PR fixes the issue.